### PR TITLE
change Dependencies to Depends in DESCRIPTION + remove import_packages.R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,10 +8,11 @@ Description: Package for easier wrangling of precipitation data provided in Adva
 License: What license is it under?
 Encoding: UTF-8
 LazyData: true
-Dependencies: data.table,
-              rgdal,
-              sp,
-              raster,
-              ncdf4,
-              ggplot2
+Depends: 
+  data.table,
+  rgdal,
+  sp,
+  raster,
+  ncdf4,
+  ggplot2
 RoxygenNote: 7.1.0

--- a/R/import_packages.R
+++ b/R/import_packages.R
@@ -1,6 +1,0 @@
-#' @import data.table
-#' @import rgdal
-#' @import sp
-#' @import raster
-#' @import ncdf4
-NULL


### PR DESCRIPTION
Hi Ivana,

there was a typo in the DESCRIPTION file - the field to include the packages is called "Depends" not "Dependencies". After you change it, you do not need the import_packages.R script.

Martin